### PR TITLE
fix: fallback to address from the node when service host is empty

### DIFF
--- a/src/main/catalog/Catalog.ts
+++ b/src/main/catalog/Catalog.ts
@@ -162,8 +162,18 @@ export class Catalog {
                 if (res.length > 0) {
                     // Pick a random service from the list of healthy services
                     const ID = Math.floor(Math.random() * res.length)
-                    const address: string = res[ID].Service.Address
-                    const port: number = res[ID].Service.Port || 80
+                    /*
+                    https://www.consul.io/api/catalog.html#serviceaddress
+                    ServiceAddress is the IP address of the service host — if empty, node
+                    address should be used
+                    */
+                    const pickedNode = res[ID]
+                    const address: string =
+                        pickedNode.Service.Address &&
+                        pickedNode.Service.Address !== ''
+                            ? pickedNode.Service.Address
+                            : pickedNode.Node.Address
+                    const port: number = pickedNode.Service.Port || 80
                     return `${address}:${port}`
                 } else {
                     throw new Error(
@@ -229,12 +239,16 @@ export class Catalog {
                                     ServiceAddress is the IP address of the service host — if empty, node
                                     address should be used
                                     */
+                                    const pickedNode = metadata[ID]
                                     const address: string =
-                                        metadata[ID].Service.Address || metadata[ID].Node.Address
+                                        pickedNode.Service.Address &&
+                                        pickedNode.Service.Address !== ''
+                                            ? pickedNode.Service.Address
+                                            : pickedNode.Node.Address
                                     const port: number =
-                                        metadata[ID].Service.Port || 80
+                                        pickedNode.Service.Port || 80
                                     const modifyIndex: number =
-                                        metadata[ID].Service.ModifyIndex
+                                        pickedNode.Service.ModifyIndex
                                     numRetries = 0
 
                                     if (modifyIndex !== index) {

--- a/src/main/catalog/Catalog.ts
+++ b/src/main/catalog/Catalog.ts
@@ -224,8 +224,13 @@ export class Catalog {
                                         Math.random() * metadata.length,
                                     )
 
+                                    /*
+                                    https://www.consul.io/api/catalog.html#serviceaddress
+                                    ServiceAddress is the IP address of the service host — if empty, node
+                                    address should be used
+                                    */
                                     const address: string =
-                                        metadata[ID].Service.Address
+                                        metadata[ID].Service.Address || metadata[ID].Node.Address
                                     const port: number =
                                         metadata[ID].Service.Port || 80
                                     const modifyIndex: number =

--- a/src/tests/integration/Catalog.spec.ts
+++ b/src/tests/integration/Catalog.spec.ts
@@ -94,6 +94,47 @@ describe('KvStore', () => {
                 })
             })
         })
+
+        it('should resolve to the node address if the service registered did not have address field', async () => {
+            return client
+                .registerEntity({
+                    Node: 'bango',
+                    Address: '192.168.4.19',
+                    Service: {
+                        ID: 'my-thing3',
+                        Service: 'my-thing3',
+                        Port: 8080,
+                    },
+                })
+                .then((success: boolean) => {
+                    expect(success).to.equal(true)
+                    return client
+                        .resolveAddress('my-thing3')
+                        .then((address: string) => {
+                            expect(address).to.equal('192.168.4.19:8080')
+                        })
+                })
+        })
+
+        it('should resolve to the node address and port to 80, if the service registered did not have address and port fields', async () => {
+            return client
+                .registerEntity({
+                    Node: 'bango',
+                    Address: '192.168.4.19',
+                    Service: {
+                        ID: 'my-thing3',
+                        Service: 'my-thing3',
+                    },
+                })
+                .then((success: boolean) => {
+                    expect(success).to.equal(true)
+                    return client
+                        .resolveAddress('my-thing3')
+                        .then((address: string) => {
+                            expect(address).to.equal('192.168.4.19:80')
+                        })
+                })
+        })
     })
 
     describe('With fail over', () => {
@@ -118,7 +159,11 @@ describe('KvStore', () => {
 
         it('should list available services', async () => {
             return client.listServices().then((services: any) => {
-                expect(services).to.equal({ consul: [], 'my-thing': [] })
+                expect(services).to.equal({
+                    consul: [],
+                    'my-thing': [],
+                    'my-thing3': [],
+                })
             })
         })
 


### PR DESCRIPTION
Fallback to the address from node when serverAddress is absent. (https://www.consul.io/api/catalog.html#serviceaddress)