### PR TITLE
Remove retry limit on HTTP 404

### DIFF
--- a/src/main/kv-store/KvStore.ts
+++ b/src/main/kv-store/KvStore.ts
@@ -125,13 +125,10 @@ export class KvStore {
                                     break
 
                                 case 404:
-                                    logger.error(
-                                        `Unable to find value for key[${key.path}]`,
+                                    logger.warn(
+                                        `Unable to find value for key[${key.path}]. Retrying...`,
                                     )
-                                    if (numRetries < this.maxRetries) {
-                                        setTimeout(_watch, 5000)
-                                        numRetries += 1
-                                    }
+                                    setTimeout(_watch, 5000)
                                     break
 
                                 default:

--- a/src/tests/unit/Observer.spec.ts
+++ b/src/tests/unit/Observer.spec.ts
@@ -46,5 +46,21 @@ describe('Observer', () => {
                 })
             })
         })
+
+        it('should alert callback when Observer presents an error', async () => {
+            return new Promise((resolve, reject) => {
+                const expected: string = 'failure'
+                const ob: Observer<string> = new Observer((sink) => {
+                    setTimeout(() => {
+                        sink(new Error(expected), undefined)
+                    })
+                })
+
+                ob.onError((err: Error) => {
+                    expect(err.message).to.equal(expected)
+                    resolve()
+                })
+            })
+        })
     })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Removed maximum retry limit in the case of HTTP 404 to allow constant polling of upstream services in the case of an HTTP 404.
- Updated logging level from error to warn
- Added unit test to cover Observable error scenarios 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to allow remote 404s to continue polling until a connection can be established. There are use cases where this is a valid scenario and prevents the need for application restarts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested in tandem with changes to [@creditkarma/dynamic-config](https://github.com/creditkarma/dynamic-config/pull/54) internally and validated to be working as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes (existing integration test covers the retry scenario).
- [x] All new and existing tests passed.
